### PR TITLE
Standardize license headers in TOML/YAML files

### DIFF
--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -1,4 +1,5 @@
-# Ultralytics 🚀 - AGPL-3.0 License https://ultralytics.com/license
+# Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license
+
 # Ultralytics Actions https://github.com/ultralytics/actions
 # This workflow automatically formats code and documentation in PRs to official Ultralytics standards
 


### PR DESCRIPTION
This PR updates all YAML file headers to use a standardized license format. 🔄

### Changes:

- 📝 Standardized header: `# Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license`
- 🧹 Ensures consistent spacing after headers
- 🔍 Applies to all YAML files except those in `venv`

Learn more about [Ultralytics licensing](https://ultralytics.com/license) 📚

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary  
Updated formatting and licensing information in the GitHub workflow file.

### 📊 Key Changes  
- Adjusted the comment formatting for the licensing line in `.github/workflows/format.yml`.  
  - Old: `# Ultralytics 🚀 - AGPL-3.0 License https://ultralytics.com/license`  
  - New: `# Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license`

### 🎯 Purpose & Impact  
- 🖹 **Improved Clarity**: Cleaner and more consistent formatting enhances readability.  
- 🔐 **Transparency**: Reinforces understanding of the licensing terms upfront, supporting compliance.  
- 💡 **No Functional Changes**: This is purely a cosmetic/comment improvement and does not impact code behavior.