### PR TITLE
Fix ecef2lla altitude conversion

### DIFF
--- a/transformations/ecef2lla.m
+++ b/transformations/ecef2lla.m
@@ -29,16 +29,17 @@ z = xyz(:,3)*1000;
 
 % WGS84 ellipsoid constants:
 a = 6378137;
-es = (8.1819190842622e-2)^2;
+e = 8.1819190842622e-2;
+es = e^2;
 
 % calculations:
 b   = sqrt(a^2*(1-es));
-ep  = (a^2-b^2)/b^2;
+ep  = sqrt((a^2-b^2)/b^2);
 
 p   = sqrt(x.^2+y.^2);
 th  = atan2(a*z,b*p);
 lon = atan2(y,x);
-lat = atan2((z+ep^2.*b.*sin(th).^3),(p-es^2.*a.*cos(th).^3));
+lat = atan2((z+ep^2.*b.*sin(th).^3),(p-es.*a.*cos(th).^3));
 N   = a./sqrt(1-es.*sin(lat).^2);
 alt = p./cos(lat)-N;
 


### PR DESCRIPTION
Fixes #20.

This corrects the WGS84 eccentricity terms in `transformations/ecef2lla.m` so latitude and altitude use the same formulation as the referenced implementation.

Validation:
- Round-tripped known WGS84 LLA/ECEF samples in Python against the MATLAB formula; old formula was tens of kilometers low in altitude, corrected formula returns near-zero altitude error.

Deleted: incorrect extra squaring of first and second eccentricity terms in `ecef2lla.m`.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Improves the accuracy of ECEF-to-LLA coordinate conversion by correcting eccentricity calculations in `ecef2lla.m` 🌍

### 📊 Key Changes
- Defines the WGS84 eccentricity `e` separately, then computes squared eccentricity `es` from it ✅
- Corrects the second eccentricity calculation `ep` to use the square root as expected 📐
- Fixes the latitude calculation to use `es` instead of `es^2`, preventing incorrect scaling in the denominator 🛠️

### 🎯 Purpose & Impact
- Improves geospatial conversion accuracy for latitude, longitude, and altitude outputs 🎯
- Reduces potential positioning errors when converting Earth-Centered, Earth-Fixed coordinates to latitude/longitude/altitude 🛰️
- Benefits users relying on MATLAB transformations for navigation, mapping, robotics, aerospace, or GPS-related workflows 🚀